### PR TITLE
Configure an additional env variable for mock data

### DIFF
--- a/familiar-mythic-arena/rankings-client/package.json
+++ b/familiar-mythic-arena/rankings-client/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "react-scripts build",
     "start": "react-scripts start",
+    "start:mock": "REACT_APP_USE_MOCK_DATA=true react-scripts start",
     "test": "react-scripts test --watchAll=false --runInBand",
     "test:watch": "react-scripts test --runInBand",
     "-----": "-----",

--- a/familiar-mythic-arena/rankings-client/src/metadata.js
+++ b/familiar-mythic-arena/rankings-client/src/metadata.js
@@ -1,6 +1,8 @@
 export const metadata = {
   appName: 'myFamiliar',
-  productName: 'Familiar: Mythic Arena'
+  productName: 'Familiar: Mythic Arena',
+  env: process.env.NODE_ENV,
+  useMockData: !!process.env.REACT_APP_USE_MOCK_DATA
 }
 
 export default metadata

--- a/familiar-mythic-arena/rankings-client/src/state/reducers.js
+++ b/familiar-mythic-arena/rankings-client/src/state/reducers.js
@@ -5,8 +5,8 @@ import metadata from './metadata'
 import testDispatch from './testDispatch'
 
 const reducers = combineReducers({
-  account,
   metadata,
+  account,
   test: testDispatch
 })
 


### PR DESCRIPTION
Allows us to continue developing the front-end while only utilizing mock data.  The primary benefit is that the front-end can remain deployed on free tiers while the server remains unbuilt.